### PR TITLE
🐛 Fix for #11

### DIFF
--- a/octoprint_TemperatureFailsafe/__init__.py
+++ b/octoprint_TemperatureFailsafe/__init__.py
@@ -90,9 +90,11 @@ class TemperatureFailsafe(octoprint.plugin.AssetPlugin,
 			if k == 'bed':
 				threshold_high = self._settings.get_int(['bed'])
 				threshold_low = self._settings.get_int(['bed_low'])
-			else:
+			elif k.startswith('tool'):
 				threshold_high = self._settings.get_int(['hotend'])
 				threshold_low = self._settings.get_int(['hotend_low'])
+			else:
+				continue
 
 			violation = False
 			errmsg = u"TemperatureFailSafe violation, heater: {heater}: {temp}C {exp} {threshold}C"


### PR DESCRIPTION
!= bed doesn't automatically mean == toolX

1.3.11 adds a new entry `chamber` here and the way too lenient logic in this plugin can't handle that.