### PR TITLE
Updating to work with python3 and OctoPrint 1.4.x

### DIFF
--- a/octoprint_TemperatureFailsafe/__init__.py
+++ b/octoprint_TemperatureFailsafe/__init__.py
@@ -199,6 +199,7 @@ class TemperatureFailsafe(octoprint.plugin.AssetPlugin,
 		)
 
 __plugin_name__ = "TemperatureFailsafe"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 plugin_identifier = "TemperatureFailsafe"
 plugin_package = "octoprint_TemperatureFailsafe"
 plugin_name = "OctoPrint-TemperatureFailsafe"
-plugin_version = "0.2.2"
+plugin_version = "0.2.3"
 plugin_description = """OctoPrint plugin to execute a shell command on temperature threshold violations"""
 plugin_author = "Uriah Welcome"
 plugin_author_email = "uriah@google.com"


### PR DESCRIPTION
Tiny pull request to bump the version and add the python 3 check.